### PR TITLE
Lesson 4 fails on *nix.

### DIFF
--- a/rxkoans.html
+++ b/rxkoans.html
@@ -7,7 +7,7 @@
 	<script type="text/javascript" src="lib/qunit.js"></script>
 	<script type="text/javascript" src="lib/rx.js"></script>
 	<script type="text/javascript" src="lib/rx.aggregates.js"></script>
-	<script type="text/javascript" src="lib/rx.jquery.js"></script>
+	<script type="text/javascript" src="lib/rx.jQuery.js"></script>
 	<script type="text/javascript" src="lib/koanutils.js"></script>
 	<script type="text/javascript" src="koans/lesson1-observablestreams.js"></script>
 	<script type="text/javascript" src="koans/lesson2-ComposableObservations.js"></script>


### PR DESCRIPTION
Fix lib/rx.jQuery.js casing to make it load properly on *nix. $() references in Lesson 4 should now work as expected.
